### PR TITLE
Auto session timeout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "2.7.2"
 
+gem "auto-session-timeout"
 gem "bootsnap", ">= 1.4.4", require: false
 gem "bootstrap", "~> 5.0.0.beta1"
 gem "devise"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,8 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
+    auto-session-timeout (0.9.7)
+      actionpack (>= 3.2, < 7)
     autoprefixer-rails (10.2.4.0)
       execjs
     bcrypt (3.1.16)
@@ -288,6 +290,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  auto-session-timeout
   bootsnap (>= 1.4.4)
   bootstrap (~> 5.0.0.beta1)
   byebug

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   include Pundit
 
   before_action :configure_permitted_parameters, if: :devise_controller?
+  auto_session_timeout 1.hour
 
   private
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Users
+  class SessionsController < Devise::SessionsController
+    auto_session_timeout_actions
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,5 @@
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable, :validatable
+  devise :database_authenticatable, :registerable, :validatable, :timeoutable
 
   has_many :messages, dependent: :destroy
 

--- a/app/presenters/page_presenter.rb
+++ b/app/presenters/page_presenter.rb
@@ -46,7 +46,7 @@ class PagePresenter
   attr_reader :current_user, :username_param
 
   def same_user?
-    current_user.parameterized_username == username_param
+    current_user&.parameterized_username == username_param
   end
 
   def different_user?

--- a/app/views/layouts/_flashes.html.erb
+++ b/app/views/layouts/_flashes.html.erb
@@ -1,3 +1,3 @@
-<% flash.each do |key, value| %>
+<% flash.to_h.slice("danger", "alert", "warning", "success", "notice").each do |key, value| %>
   <%= content_tag :div, value, :class => "flash-#{key}" unless value.blank? %>
 <% end %>

--- a/app/views/layouts/_timeout.html.erb
+++ b/app/views/layouts/_timeout.html.erb
@@ -1,0 +1,3 @@
+<% if current_user %>
+  <%= auto_session_timeout_js frequency: 60.seconds %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,7 @@
 </head>
 
 <body data-current-user-id="<%= current_user&.id %>">
+<%= render 'layouts/timeout' %>
 <%= render 'layouts/navigation' %>
 <%= render 'layouts/flashes' %>
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -188,7 +188,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  config.timeout_in = 1.hour
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.
@@ -277,10 +277,9 @@ Devise.setup do |config|
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.
   #
-  # config.warden do |manager|
-  #   manager.intercept_401 = false
-  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
-  # end
+  config.warden do |manager|
+    manager.failure_app = CustomFailureApp
+  end
 
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine
@@ -308,4 +307,10 @@ Devise.setup do |config|
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
+end
+
+class CustomFailureApp < Devise::FailureApp
+  def redirect_url
+    scope_url  # Always redirect to login page
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,15 +1,19 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: { sessions: "users/sessions" }
+
   devise_scope :user do
     authenticated :user do
       root "welcome#index", as: :authenticated_root
     end
 
     unauthenticated do
-      root "devise/sessions#new", as: :unauthenticated_root
+      root "users/sessions#new", as: :unauthenticated_root
     end
+
+    get "active" => "users/sessions#active"
+    get "timeout" => "users/sessions#timeout"
   end
 
   resources :pages, only: :show


### PR DESCRIPTION
Currently we have no indication when a session times out. 

This PR checks each minute and will time out and redirect to the login screen when the user has been inactive for an hour.