### PR TITLE
Remove email and add system specs

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,3 @@
+# Copy this file to a new file called .env
+
+SIGN_UP_TOKEN=my_token

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -42,6 +42,6 @@ jobs:
       - name: Install node dependencies
         run: yarn install --frozen-lockfile
       - name: Create database
-        run: RAILS_ENV=test bundle exec rails db:setup
+        run: RAILS_ENV=test bundle exec rails db:create db:schema:load
       - name: Run tests
         run: bundle exec rspec

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Ignore bundler config.
 /.bundle
 
+# Ingore the local .env file
+.env
+
 # Ignore the default SQLite database.
 /db/*.sqlite3
 /db/*.sqlite3-*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -92,3 +92,6 @@ Style/StringLiterals:
 Style/SymbolArray:
   Description: Checks for symbol arrays using the %i() syntax
   EnforcedStyle: brackets
+
+Style/TrailingCommaInHashLiteral:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,6 +51,9 @@ Metrics/ModuleLength:
 
 # Styles that are modified from the defaults
 
+Naming/VariableNumber:
+  Enabled: false # variables like message_1 are actually better
+
 Style/Alias:
   Description: Use alias_method instead of alias in a class or module body
   EnforcedStyle: prefer_alias_method

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "bootsnap", ">= 1.4.4", require: false
 gem "bootstrap", "~> 5.0.0.beta1"
 gem "devise"
 gem "devise-bootstrap-views"
+gem "dotenv-rails"
 gem "font_awesome5_rails"
 gem "image_processing", "~> 1.2"
 gem "local_time"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,10 @@ GEM
       warden (~> 1.2.3)
     devise-bootstrap-views (1.1.0)
     diff-lcs (1.4.4)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.10.0)
     execjs (2.7.0)
     factory_bot (6.1.0)
@@ -299,6 +303,7 @@ DEPENDENCIES
   capybara (>= 3.26)
   devise
   devise-bootstrap-views
+  dotenv-rails
   factory_bot_rails
   faker
   font_awesome5_rails

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Users
+  class RegistrationsController < Devise::RegistrationsController
+    # POST /resource
+    def create
+      if params[:sign_up_token] == ::FireSwampConfig.sign_up_token
+        super
+      else
+        flash[:alert] = "Invalid sign up token"
+        redirect_to new_user_registration_path
+      end
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
-  devise :database_authenticatable, :registerable, :validatable, :timeoutable
+  devise :database_authenticatable, authentication_keys: [:username]
+  devise :registerable, :validatable, :timeoutable
 
   has_many :messages, dependent: :destroy
 
@@ -7,6 +8,14 @@ class User < ApplicationRecord
   validates_presence_of :parameterized_username
 
   before_validation :set_parameterized_username, if: :username_changed?
+
+  def email_required?
+    false
+  end
+
+  def will_save_change_to_email?
+    false
+  end
 
   def to_param
     username&.parameterize&.underscore

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -6,8 +6,8 @@
   <%= bootstrap_devise_error_messages! %>
 
   <div class="form-group">
-    <%= f.label :email %>
-    <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control' %>
+    <%= f.label :username %>
+    <%= f.text_field :username, autofocus: true, autocomplete: 'username', class: 'form-control' %>
   </div>
 
   <div class="form-group">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -8,13 +8,8 @@
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name), data: {turbo: false}) do |f| %>
 
     <div class="mb-3 required">
-      <%= f.label :email, class: "form-label" %>
-      <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control' %>
-    </div>
-
-    <div class="mb-3 required">
       <%= f.label :username, class: "form-label" %>
-      <%= f.text_field :username, autocomplete: 'username', class: 'form-control' %>
+      <%= f.text_field :username, autofocus: true, autocomplete: 'username', class: 'form-control' %>
     </div>
 
     <div class="mb-3 required">
@@ -29,6 +24,11 @@
     <div class="mb-3 required">
       <%= f.label :password_confirmation, class: "form-label" %>
       <%= f.password_field :password_confirmation, autocomplete: 'current-password', class: 'form-control' %>
+    </div>
+
+    <div class="mb-3 required">
+      <%= label_tag(:sign_up_token, "Sign Up Token", class: "form-label") %>
+      <%= password_field_tag(:sign_up_token, nil, class: "form-control") %>
     </div>
 
     <div class="mb-3">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -27,7 +27,7 @@
     </div>
 
     <div class="mb-3 required">
-      <%= label_tag(:sign_up_token, "Sign Up Token", class: "form-label") %>
+      <%= label_tag(:sign_up_token, "Sign up token", class: "form-label") %>
       <%= password_field_tag(:sign_up_token, nil, class: "form-control") %>
     </div>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -5,8 +5,8 @@
 <article class="container">
   <%= form_for(resource, as: resource_name, url: session_path(resource_name), data: {turbo: false}) do |f| %>
     <div class="mb-3">
-      <%= f.label :email, class: "form-label" %>
-      <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control' %>
+      <%= f.label :username, class: "form-label" %>
+      <%= f.text_field :username, autofocus: true, autocomplete: 'username', class: 'form-control' %>
     </div>
 
     <div class="mb-3">

--- a/config/initializers/_01_fire_swamp.rb
+++ b/config/initializers/_01_fire_swamp.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module FireSwampConfig
+  def self.sign_up_token
+    ::ENV["SIGN_UP_TOKEN"]
+  end
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -46,7 +46,7 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  # config.authentication_keys = [:email]
+  config.authentication_keys = [:username]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the
@@ -58,12 +58,12 @@ Devise.setup do |config|
   # Configure which authentication keys should be case-insensitive.
   # These keys will be downcased upon creating or modifying a user and when used
   # to authenticate or find a user. Default is :email.
-  config.case_insensitive_keys = [:email]
+  config.case_insensitive_keys = [:username]
 
   # Configure which authentication keys should have whitespace stripped.
   # These keys will have whitespace before and after removed upon creating or
   # modifying a user and when used to authenticate or find a user. Default is :email.
-  config.strip_whitespace_keys = [:email]
+  config.strip_whitespace_keys = [:username]
 
   # Tell if authentication through request.params is enabled. True by default.
   # It can be set to an array that will enable params authentication only for the
@@ -157,7 +157,7 @@ Devise.setup do |config|
   # initial account confirmation) to be applied. Requires additional unconfirmed_email
   # db field (see migrations). Until confirmed, new email is stored in
   # unconfirmed_email column, and copied to email column on successful confirmation.
-  config.reconfirmable = true
+  # config.reconfirmable = true
 
   # Defines which key will be used when confirming an account
   # config.confirmation_keys = [:email]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  devise_for :users, controllers: { sessions: "users/sessions" }
+  devise_for :users, controllers: {
+    registrations: "users/registrations",
+    sessions: "users/sessions",
+  }
 
   devise_scope :user do
     authenticated :user do

--- a/db/migrate/20210207163742_remove_email_from_users.rb
+++ b/db/migrate/20210207163742_remove_email_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveEmailFromUsers < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :users, :email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_04_054548) do
+ActiveRecord::Schema.define(version: 2021_02_07_163742) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,13 +24,11 @@ ActiveRecord::Schema.define(version: 2021_02_04_054548) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "email", null: false
     t.string "encrypted_password", null: false
     t.string "username", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "parameterized_username"
-    t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,4 +6,4 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-User.create(email: "user@example.com", password: "password", password_confirmation: "password", username: "Master of ROUSes")
+User.create(password: "password", password_confirmation: "password", username: "Master of ROUSes")

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -2,7 +2,6 @@
 
 FactoryBot.define do
   factory :user, class: User do
-    email { Faker::Internet.email }
     username { Faker::Internet.username }
     password { "12345678" }
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,7 +5,6 @@ require "rails_helper"
 RSpec.describe ::User do
   subject { create(:user) }
 
-  it { is_expected.to validate_presence_of(:email) }
   it { is_expected.to validate_presence_of(:username) }
   it { is_expected.to validate_presence_of(:parameterized_username) }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require "rspec/rails"
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join("spec", "support", "**", "*.rb")].sort.each { |f| require f }
+Dir[Rails.root.join("spec", "support", "**", "*.rb")].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/support/basic_configure.rb
+++ b/spec/support/basic_configure.rb
@@ -4,4 +4,10 @@ RSpec.configure do |config|
   config.before(:each, type: :system) do
     driven_by :rack_test
   end
+
+  config.before(:each, type: :system, js: true) do
+    # For compatibility with Heroku CI, driven_by must be set to a Capybara registered driver
+    # that sets chromeOptions: :binary to the path of the chrome assets in the Heroku CI environment
+    driven_by :selenium_chrome_headless
+  end
 end

--- a/spec/support/basic_configure.rb
+++ b/spec/support/basic_configure.rb
@@ -1,0 +1,7 @@
+# Noel Rappin at https://medium.com/table-xi/a-quick-guide-to-rails-system-tests-in-rspec-b6e9e8a8b5f6
+
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :rack_test
+  end
+end

--- a/spec/system/user_log_in_spec.rb
+++ b/spec/system/user_log_in_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "log in", type: :system do
+  let(:initial_path) { new_user_session_path }
+  let(:username) { "rousguy"}
+  let(:password) { "12345678" }
+  before { create(:user, username: username, password: password, password_confirmation: password) }
+
+  scenario "User with proper credentials can log in" do
+    visit initial_path
+
+    fill_in "Username", with: username
+    fill_in "Password", with: password
+    click_button "Log in"
+
+    validate_user_logged_in
+  end
+
+  scenario "User with incorrect password cannot log in" do
+    visit initial_path
+
+    fill_in "Username", with: username
+    fill_in "Password", with: "random password"
+    click_button "Log in"
+
+    validate_user_not_logged_in
+  end
+
+  scenario "User with unknown username cannot log in" do
+    visit initial_path
+
+    fill_in "Username", with: "random username"
+    fill_in "Password", with: password
+    click_button "Log in"
+
+    validate_user_not_logged_in
+  end
+
+  def validate_user_logged_in
+    expect(current_path).to eq authenticated_root_path
+  end
+
+  def validate_user_not_logged_in
+    expect(current_path).to eq initial_path
+    expect(page).to have_content("Invalid Username or password")
+  end
+end

--- a/spec/system/user_log_in_spec.rb
+++ b/spec/system/user_log_in_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe "log in", type: :system do
   let(:initial_path) { new_user_session_path }
-  let(:username) { "rousguy"}
+  let(:username) { "rousguy" }
   let(:password) { "12345678" }
   before { create(:user, username: username, password: password, password_confirmation: password) }
 

--- a/spec/system/user_sign_up_spec.rb
+++ b/spec/system/user_sign_up_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "sign up", type: :system do
+  let(:initial_path) { new_user_registration_path }
+  let(:sign_up_token) { "token" }
+  before { allow(::FireSwampConfig).to receive(:sign_up_token).and_return(sign_up_token) }
+
+  scenario "Visitor with proper sign up token can create a user" do
+    visit initial_path
+
+    fill_in "Username", with: "new rous"
+    fill_in "Password", with: "password"
+    fill_in "Password confirmation", with: "password"
+    fill_in "Sign up token", with: sign_up_token
+
+    validate_user_created
+  end
+
+  scenario "Visitor without proper sign up token cannot create a user" do
+    visit initial_path
+
+    fill_in "Username", with: "new rous"
+    fill_in "Password", with: "password"
+    fill_in "Password confirmation", with: "password"
+    fill_in "Sign up token", with: "not the correct token"
+
+    validate_user_not_created
+  end
+
+  scenario "Visitor that provides no sign up token cannot create a user" do
+    visit initial_path
+
+    fill_in "Username", with: "new rous"
+    fill_in "Password", with: "password"
+    fill_in "Password confirmation", with: "password"
+
+    validate_user_not_created
+  end
+
+  def validate_user_created
+    expect { click_button "Sign up" }.to change { User.count }.by 1
+    expect(current_path).to eq authenticated_root_path
+  end
+
+  def validate_user_not_created
+    expect { click_button "Sign up" }.not_to(change { User.count })
+    expect(current_path).to eq initial_path
+    expect(page).to have_content("Invalid sign up token")
+  end
+end

--- a/spec/system/visit_chat_page_spec.rb
+++ b/spec/system/visit_chat_page_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "visit the chat page", type: :system, js: true do
+  let(:user) { create(:user) }
+
+  scenario "Visitor attempting to access the chat page is redirected to the sign in page" do
+    visit messages_path
+
+    expect(current_path).to eq new_user_session_path
+  end
+
+  scenario "User is permitted to visit the chat page and enter a message" do
+    login_as user, scope: :user
+    visit messages_path
+
+    expect(current_path).to eq messages_path
+    expect(page).to have_field("message_content")
+
+    existing_count = ::Message.count
+    fill_in("message_content", with: "Something witty\n")
+    sleep 0.5
+
+    expect(::Message.count).to eq(existing_count + 1)
+    expect(::Message.last.content).to eq("Something witty")
+    expect(page).to have_content(user.username)
+    expect(page).to have_content("Something witty")
+  end
+end

--- a/spec/system/visit_home_page_spec.rb
+++ b/spec/system/visit_home_page_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "visit the home page", type: :system do
+  let(:user) { create(:user) }
+
+  scenario "Visitor is redirected to the sign in page" do
+    visit authenticated_root_path
+
+    expect(current_path).to eq unauthenticated_root_path
+  end
+
+  scenario "User is permitted to visit the home page" do
+    login_as user, scope: :user
+    visit authenticated_root_path
+
+    expect(current_path).to eq authenticated_root_path
+  end
+end


### PR DESCRIPTION
We are currently using an email to sign up. This doesn't make a lot of sense, since we don't need to contact anyone, and they are going to use their username internally.

However, we need to have a mechanism to stop bots and miscreants from signing up as well.

This PR removes the email fields and uses username for sign up and login. It also introduces a secret "sign up token," which will exist as an environment variable and will need to be provided for any user to sign up.